### PR TITLE
chore(claude): enable semantic-commit-skill and pr-skill plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,8 @@
 {
   "enabledPlugins": {
-    "nuget-publish-skill@kudima03": true
+    "nuget-publish-skill@kudima03": true,
+    "semantic-commit-skill@kudima03": true,
+    "pr-skill@kudima03": true
   },
   "extraKnownMarketplaces": {
     "kudima03": {


### PR DESCRIPTION
## Summary
- Enable semantic-commit-skill and pr-skill (kudima03 marketplace) in .claude/settings.json, alongside the existing publish skill.

Rolled out identically across all Pure.*/PureQL* repos; reference change made in Pure.Chart.Model.