### PR TITLE
chore(claude): enable changelog-generator-skill plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,8 @@
   "enabledPlugins": {
     "nuget-publish-skill@kudima03": true,
     "semantic-commit-skill@kudima03": true,
-    "pr-skill@kudima03": true
+    "pr-skill@kudima03": true,
+    "changelog-generator-skill@kudima03": true
   },
   "extraKnownMarketplaces": {
     "kudima03": {


### PR DESCRIPTION
## Summary
- Enable changelog-generator-skill (kudima03 marketplace) in .claude/settings.json, alongside the existing plugins.

Rolled out identically across all Pure.*/PureQL* repos; reference change made in Pure.Chart.Model.